### PR TITLE
fix(flowConfig): json key for rawAccount struct

### DIFF
--- a/examples/flow.json
+++ b/examples/flow.json
@@ -44,32 +44,32 @@
 	"accounts": {
 		"emulator-account": {
 			"address": "f8d6e0586b0a20c7",
-			"keys": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
+			"key": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
 			"chain": "flow-emulator"
 		},
 		"first" : {
 			"address": "1cf0e2f2f715450",
-      "keys": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
+      "key": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
 			"chain": "flow-emulator"
 		},
 		"second" : {
 			"address": "179b6b1cb6755e31",
-      "keys": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
+      "key": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
 			"chain": "flow-emulator"
 		},
 		"emulator3" : {
 			"address": "f3fcd2c1a78f5eee",
-      "keys": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
+      "key": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
 			"chain": "flow-emulator"
 		},
 		"emulator4" : {
 			"address": "e03daebed8ca0615",
-      "keys": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
+      "key": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
 			"chain": "flow-emulator"
 		},
 		"emulator5" : {
 			"address": "045a1763c93006ca",
-      "keys": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
+      "key": "1cd391b90c98671d3f07c7104f016c4704242704d8a7ad7d2126c6d5331516e8",
 			"chain": "flow-emulator"
 		}
 	},

--- a/gwtf/flowConfig.go
+++ b/gwtf/flowConfig.go
@@ -19,7 +19,7 @@ type RawFlowConfig struct {
 // RawAccount flow accounts struct for marshalling into primitive types
 type RawAccount struct {
 	Address    string `json:"address"`
-	Keys 	   string `json:"keys"`
+	Keys 	   string `json:"key"`
 }
 
 // NewRawFlowConfig will read the flow.json file

--- a/gwtf/flowConfig.go
+++ b/gwtf/flowConfig.go
@@ -19,7 +19,7 @@ type RawFlowConfig struct {
 // RawAccount flow accounts struct for marshalling into primitive types
 type RawAccount struct {
 	Address    string `json:"address"`
-	Keys 	   string `json:"key"`
+	Keys 	   string `json:"keys"`
 }
 
 // NewRawFlowConfig will read the flow.json file


### PR DESCRIPTION
This fix assumes the flow.json should use `keys` for the key. 